### PR TITLE
Add file rearangement to batch workflow

### DIFF
--- a/tasks/arrange-files.rb
+++ b/tasks/arrange-files.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+# read a single rof file (name given on command line)
+# and rearrange files for its objects
+
+require 'json'
+require 'fileutils'
+
+jobpath = ENV['JOBPATH']
+abort("No JOBPATH") if jobpath.nil?
+
+rof_objects = []
+
+rof_file = ARGV[0]
+File.open(rof_file, "r") do |f|
+  rof_objects.concat(JSON.load(f.read()))
+end
+
+bendo_url_re = Regexp.new("^bendo:/item/([^/]+)/(.*)")
+
+rof_objects.each do |obj|
+  # if bendo-item entry, save this obj to file system
+  bendo_item = obj['bendo-item']
+  next unless bendo_item
+  pid = obj['pid']
+  abort("Missing PID") if pid.nil?
+  # remove "und:" prefix if present
+  pid = pid.sub(/\Aund:/,"")
+  # dump this object into its own rof file
+  dst = File.join(jobpath, "TO_TAPE", bendo_item, "fedora3", pid + ".rof")
+  puts "Writing #{dst}"
+  FileUtils.mkdir_p(File.dirname(dst))
+  File.open(dst, "w") do |f|
+    # put the object into an array so it matches the rof format
+    JSON.dump([obj], f)
+  end
+
+  # now scan for URL entries and move files as necessary
+  obj.each do |k,v|
+    next unless k.end_with?("-meta")
+    next unless v['URL']
+    # the target bendo item is capture 1
+    # the target file path is capture 2
+    m = bendo_url_re.match(v['URL'])
+    next if m.nil?
+    src = File.join(jobpath, m[2])
+    dst = File.join(jobpath, "TO_TAPE", m[1], m[2])
+    # if the file exists don't overwrite it
+    if File.exist?(dst)
+      puts "Keeping #{dst}"
+      next
+    end
+    puts "Moving #{dst}"
+    FileUtils.mkdir_p(File.dirname(dst))
+    FileUtils.mv(src, dst)
+  end
+end

--- a/tasks/move-files-for-bendo
+++ b/tasks/move-files-for-bendo
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Rearrange files to prepare for bendo ingest.
+# this file exists to springboard into arrange-files.rb
+# (Why? because we need to use bundler to get a newer ruby)
+
+scriptdir=$(cd $(dirname $0); pwd)
+source $scriptdir/conf
+
+export JOBPATH
+
+cd $gemfile_dir
+for f in "$JOBPATH"/metadata-*.rof; do
+    if [ ! -e $f ]; then
+        echo "No ROF files in job directory"
+        exit 1
+    fi
+
+    if su app -c "bundle exec tasks/arrange-files.rb $f"; then
+        true
+    else
+        echo "error with $f"
+        exit 1
+    fi
+done

--- a/tasks/start
+++ b/tasks/start
@@ -13,6 +13,7 @@ echo 'addtask:assign-pids' >> $JOBCONTROL
 echo 'addtask:date-stamp' >> $JOBCONTROL
 echo 'addtask:validate' >> $JOBCONTROL
 echo 'addtask:extract-collections' >> $JOBCONTROL
+echo 'addtask:move-files-for-bendo' >> $JOBCONTROL
 echo 'addtask:ingest' >> $JOBCONTROL
 echo 'addtask:index' >> $JOBCONTROL
 echo 'addtask:characterize' >> $JOBCONTROL


### PR DESCRIPTION
 * Rearrange files so that the bendo upload tool can just upload directories directly into bendo.
 * Save the rof file for each fedora object into its own file for upload into bendo.