### PR TITLE
Add logging when jobs are finished

### DIFF
--- a/batchs/engine.go
+++ b/batchs/engine.go
@@ -50,6 +50,7 @@ func (ctx *Context) Run() error {
 				jb.state = StateSuccess
 			}
 		}
+		log.Printf("Done processing job %s (%s)", jb.name, jb.state)
 		ctx.callWebhooks(jb)
 		err = ctx.q.FinishJob(jb)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,11 @@ func (li *loginfo) Reopen() {
 
 func signalHandler(sig <-chan os.Signal, logw Reopener) {
 	for s := range sig {
+		if s == syscall.SIGCHLD {
+			// each call to exec will generate a SIGCHLD when the child process exits.
+			// We don't care about them.
+			continue
+		}
 		log.Println("Received signal", s)
 		switch s {
 		case syscall.SIGUSR1:


### PR DESCRIPTION
Also remove logging SIGCHLD signals. They occur every time a child
spawned by exec exits, and adds noise to the log.