### PR TITLE
Remove http prefix when using fedora_url variable

### DIFF
--- a/tasks/fedora-to-rof
+++ b/tasks/fedora-to-rof
@@ -16,10 +16,9 @@ if [ ! -e "$pid_file" ]; then
 fi
 
 # Iterate through pids- use rof fedor_to_rof to retrieve from fedora and generate rof
-for pid  in $(jq 'keys' < $pid_file | jq --raw-output '.[]'); do
+for pid  in $(jq --raw-output 'keys|.[]' $pid_file | sed 's/und://'); do
 
-  rof_file=$(echo ${pid} | sed 's/und://')
-  if ! bundle exec fedora_to_rof --fedora http://${fedora_url} --user "${fedora_user}:${fedora_pass}"  --outfile "$JOBPATH"/"$rof_file".rof  $pid; then
+  if ! bundle exec fedora_to_rof --fedora ${fedora_url} --user "${fedora_user}:${fedora_pass}"  --outfile "$JOBPATH/$pid.rof"  $pid; then
     exit 1
   fi
 done


### PR DESCRIPTION
Also consolidate the `jq` invocations so there is only one.

DLTP-603