### PR TITLE
Keep trying to bind to HTTP port

### DIFF
--- a/batchs/routes.go
+++ b/batchs/routes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -21,19 +22,20 @@ type RESTServer struct {
 }
 
 // Run initializes and starts all the goroutines used by the server. It then
-// blocks listening for and handling http requests.
-func (s *RESTServer) Run() error {
+// blocks listening for and handling http requests. This function never returns.
+func (s *RESTServer) Run() {
 	if s.PortNumber == "" {
 		s.PortNumber = "15000"
 	}
 
-	err := http.ListenAndServe(":"+s.PortNumber, s.addRoutes())
+	for {
+		err := http.ListenAndServe(":"+s.PortNumber, s.addRoutes())
 
-	if err != nil {
-		log.Println(err)
+		if err != nil {
+			log.Println(err)
+			time.Sleep(5 * time.Second) // duration is arbitrary
+		}
 	}
-
-	return err
 }
 
 func (server *RESTServer) addRoutes() http.Handler {

--- a/main.go
+++ b/main.go
@@ -117,15 +117,13 @@ func main() {
 	fs := batchs.NewFileQueue(*queuepath)
 	ctx := batchs.NewContext(fs, *taskpath, version)
 
-	hs := batchs.RESTServer{
+	//Start the HTTPD Server thread
+	serverHTTP := batchs.RESTServer{
 		QueuePath:  fs,
 		PortNumber: *portNumber,
 		Version:    version,
 	}
-
-	//Start the HTTPD Server thread
-
-	go hs.Run()
+	go serverHTTP.Run()
 
 	// Start the batchs server thread
 


### PR DESCRIPTION
This patch puts the HTTP server's ListenAndConnect into an infinte loop
so that if there is an error connecting we will keep trying until it is
successful. Right now the timeout for errors is 5 seconds.
The goal of this patch is to prevent a production issue from happening
again...the batchs server was restarted at one point and for some reason
it couldn't immediately bind to port 15000, and so it never started
listening on the port and other services were then erroring out. Yet the
batch processing was working just fine.