### PR TITLE
Adds a swagger 2.0 definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
 Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![Go Report
 Card](https://goreportcard.com/badge/github.com/ndlib/curatend-batch)](https://goreportcard.com/report/github.com/ndlib/curatend-batch)
+<img src="http://online.swagger.io/validator?url=https://raw.githubusercontent.com/ndlib/curatend-batch/master/definitions/swagger.yml">
 
 This repository provides code to run the batch ingest infrastructure for
 [CurateND].  Most of the code to perform the actual processing is in the

--- a/definitions/swagger.yml
+++ b/definitions/swagger.yml
@@ -1,0 +1,192 @@
+swagger: "2.0"
+info:
+  title: "Batch Ingest API for CurateND"
+  description: "This API is intended to provide a convenient, non-file system based, way for other services to create and check on batch jobs"
+  version: "1.1.6"
+externalDocs:
+  description: "Source code documentation here"
+  url: "https://github.com/ndlib/curatend-batch/blob/master/api.md"
+schemes:
+- "https"
+paths:
+  /:
+    get:
+      summary: "Returns the current running version"
+      produces:
+        - text/plain
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/Version'
+          examples:
+            text/plain:
+              "CurateND Batch (1.1.6)"
+  /jobs:
+    get:
+      summary: Returns a JSON array listing the names of all the jobs
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/AllJobs'
+          examples:
+            application/json:
+              [
+                { "Name": "job-1", "Status": "success" },
+                { "Name": "another-job", "Status": "success" },
+                { "Name": "test2", "Status": "success" }
+              ]
+        "401":
+          description: Unauthorized
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  "/jobs/{jobId}":
+    parameters:
+      - in: path
+        name: jobId
+        type: string
+        required: true
+        description: ID of a specific job
+    get:
+      summary: "This request returns the job's information as a JSON object"
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: >
+            The possible values for 'Status' are:
+            * "success" - the job completed processing successfully,
+            * "error", - the job had an error during processing,
+            * "processing", - the job is being processed,
+            * "queue", - the job is waiting to be processed,
+            * "ready" - the job has not been queued yet.
+          schema:
+            $ref: '#/definitions/EachJob'
+          examples:
+            application/json:
+              { "Name": "test2", "Status": "success" }
+    put:
+      tags:
+        - skipTests
+      summary: "A payload does not need to be provided. If one is present, it is ignored. This call is mainly used to create a job if a job with that id does not already exist."
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+    delete:
+      tags:
+        - skipTests
+      summary: "This will delete the given job and all the data and files inside it."
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+  "/jobs/{jobId}/queue":
+    parameters:
+      - in: path
+        name: jobId
+        type: string
+        required: true
+        description: ID of a specific job
+    post:
+      tags:
+      - skipTests
+      summary: "This request will ask that the given job be moved to the `queue` directory"
+      description: >
+        * It has no effect if the job is already in the `queue` or `processing` directories.
+
+        * If a job is moved from the "error" or "success" states to "queue", it will resume with whatever task caused an error, or the next task in the Todo list.
+
+        * To reprocess a job from the complete beginning `DELETE` the `JOB` file and then submit the job.
+      responses:
+        200:
+          description: OK
+  "/jobs/{jobId}/files":
+    parameters:
+      - in: path
+        name: jobId
+        type: string
+        required: true
+        description: ID of a specific job
+    get:
+      summary: "This request will return an array of filenames and/or subdirectories"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GetFilesResponse'
+          examples:
+            application/json:
+             ["filename1", "subdirectory1", "filenam2", "subdirectory2"]
+  "/jobs/{jobId}/files/{pathName}":
+    parameters:
+      - in: path
+        name: jobId
+        type: string
+        required: true
+        description: ID of a specific job
+      - in: path
+        name: pathName
+        type: string
+        required: true
+        description: a file, a directory, or path of a file/directory
+        enum: ["fileName1", "path/to/fileName2", "directoryName1", "path/to/directoryName2"]
+    get:
+      summary: "This request will return an array of filenames and/or subdirectories."
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GetFilesResponse'
+          examples:
+            application/json:
+             ["filename1", "subdirectory1", "filenam2", "subdirectory2"]
+    put:
+      tags:
+        - skipTests
+      summary: "This request will add a file into the given job"
+      description: >
+        * The path given may contain forward slashes, and those will create subdirectories.
+
+        * It is legal to alter files used by the batch ingest service, such as `JOB`, `LOG`, and `WEBHOOK`.
+
+        * The request body is saved as the contents of the file.
+
+        * If the file already exists, it is replaced.
+      responses:
+        200:
+          description: OK
+    delete:
+      tags:
+        - skipTests
+      summary: "This request will delete a file from the given job. It is not an error to remove a file which does not exist."
+      responses:
+        200:
+          description: OK
+definitions:
+  Version:
+    type: string
+  AllJobs:
+    type: array
+    items:
+      $ref: '#/definitions/EachJob'
+  EachJob:
+    type: object
+    properties:
+      Name:
+        type: string
+      Status:
+        type: string
+  GetFilesResponse:
+    type: array
+    items:
+      type: string
+  Error:
+    type: object


### PR DESCRIPTION
* This file complies with Swagger 2.0 specifications. It can be verified on http://editor.swagger.io/#/
* All the operations with tag object 'skipTests' will not be tested because they're adding/deleting files
* This documentation is based on my understanding from the API documentation [here](https://github.com/ndlib/curatend-batch/blob/master/api.md)

## Makes an initial swagger file with /jobs endpoint

72aee589d476d40ef3be4224727826fa0bc89cca


## Adds GET '/' operation and a 'produces' field

334bae56c65c6ff91ded75dd52c746b34aba3098


## Adds definition for GET '/jobs/{jobId}'

b4c942e598af782fb1ec899292bc430dd3715744


## Adds definition for PUT and DELETE '/jobs/{jobId}'

7e9c11a080e3433482c7aa6d19c219220ebae76d


## Adds definition for POST '/jobs/{jobId}/queue'

bf7e1c60a6eb89d2f610c6d56e982f53cf603ee8


## Moves summary at the operation scope

7718ff76b2df1e323c1e5bbf6ddb49c912650b9f


## Adds operations for

6596c6576b69ef0f56f1fc14d7ed390690ae2e4c

## Adds missing 'responses' object to PUT '/jobs/{jobId}/files/{pathName}' operation

d727b9b53227afbca9e690406d0424890639827d


## Splits "/jobs/{jobId}/files" operation

67e09e553cfbfedf488594309a0fd475e10f9854

* Swagger 2.0 mandates that path parameters cannot be optional.
Hence I'm splitting up `/jobs/{jobId}/files` into two operations
1. `/jobs/{jobId}/files` which returns files/folders at root of job
2. `/jobs/{jobId}/files/{pathName}` which returns file or subdirectories

* As Don identified in the PR review, I'm also changing schema of
 GetFilesResponse from object to array type

## Adds a swagger validator badge

362ac4794b58d3c4b422dac929a254d2ff87b56c