### PR TITLE
Filter BOM bytes from csv files

### DIFF
--- a/tasks/remove-csv-bom
+++ b/tasks/remove-csv-bom
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Remove any UTF byte order marks from CSV files since utf-8 doesn't need them
+# and Excel insists on adding them.
+
+scriptdir=$(cd $(dirname $0); pwd)
+source "$scriptdir"/conf
+
+#cd "$gemfile_dir"
+for csv_file in "$JOBPATH"/metadata-*.csv; do
+  echo "$JOBPATH"
+  echo "$csv_file"
+  if [ ! -e "$csv_file" ]; then
+    echo "No metadata-* CSV files in job directory"
+    exit 1
+  fi
+
+  # Tried using sed but there are differences between BSD (osx) and GNU sed.
+  perl -i.bak -pe 's/\xef\xbb\xbf//' "${csv_file}"
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+  rm "${csv_file}.bak"
+done

--- a/tasks/start
+++ b/tasks/start
@@ -10,6 +10,7 @@ if [ -z $(find "$JOBPATH" -maxdepth 1 -name 'metadata-*.rof' -print -quit) ]; th
     echo 'addtask:jsonld-to-rof' >> $JOBCONTROL
   else
     # no jsonld or rof files, so process any csv files
+    echo 'addtask:remove-csv-bom' >> "$JOBCONTROL"
     echo 'addtask:csv-to-rof' >> "$JOBCONTROL"
   fi
 fi


### PR DESCRIPTION
The ruby processing code does not ignore them. And excel loves to add
them. They are only stripped from csv files.

DLTP-1573