### PR TITLE
Run filename-normalize after file-to-url

### DIFF
--- a/tasks/start
+++ b/tasks/start
@@ -16,8 +16,8 @@ if [ -z $(find "$JOBPATH" -maxdepth 1 -name 'metadata-*.rof' -print -quit) ]; th
 fi
 echo 'addtask:work-xlat' >> "$JOBCONTROL"
 echo 'addtask:assign-pids' >> "$JOBCONTROL"
-echo 'addtask:filename-normalize' >> "$JOBCONTROL"
 echo 'addtask:file-to-url' >> "$JOBCONTROL"
+echo 'addtask:filename-normalize' >> "$JOBCONTROL"
 echo 'addtask:access-to-relsext' >> "$JOBCONTROL"
 echo 'addtask:date-stamp' >> "$JOBCONTROL"
 echo 'addtask:validate' >> "$JOBCONTROL"


### PR DESCRIPTION
Running filename-normalize before file-to-url meant the filenames were
being missed, and NOT normalized. This way, the filenames are in the URL
section of `content-meta` and filename-normalize will see them.