### PR TITLE
Change to secrets manager

### DIFF
--- a/codepipeline.yml
+++ b/codepipeline.yml
@@ -135,10 +135,10 @@ Resources:
               - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProject}"
               - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProject}:*"
           - Action:
-              - "ssm:GetParameters"
+              - "secretsmanager:GetSecretValue"
             Effect: "Allow"
             Resource:
-              - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/github/ndlib-git/oauth"
+              - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/all/github/ndlib-git-??????"
       Roles: 
         - !Ref BuildProjectServiceRole
 
@@ -247,7 +247,7 @@ Resources:
         ComputeType: !Ref CodeBuildComputeType
         Image: !Ref CodeBuildImage
         EnvironmentVariables:
-        - {Name: GITHUB_OAUTH_TOKEN, Type: PARAMETER_STORE, Value: "/all/github/ndlib-git/oauth"}
+        - {Name: GITHUB_OAUTH_TOKEN, Type: SECRETS_MANAGER, Value: "/all/github/ndlib-git:oauth::"}
       
 
   Pipeline:


### PR DESCRIPTION
AWS just released support for injecting values from SecretsManager into a CodeBuild env: https://aws.amazon.com/about-aws/whats-new/2019/11/aws-codebuild-adds-support-for-aws-secrets-manager/. Updated the codebuild to use our existing github oauth token from Secrets Manager, which will alleviate the need to have a duplicated key in SSM.