### PR TITLE
Makefile chnages for make rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ rpm: curatend-batch
 	                --rpm-user app \
 	                --rpm-group app \
 			curatend-batch=/opt/batchs/bin/curatend-batch \
-			tasks=/opt/batchs/tasks
+			tasks=/opt/batchs


### PR DESCRIPTION
make rpm's fpm directive is adding an extra level under /opt/batchs/tasks- removing it.