### PR TITLE
dltp-1813 update rof gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/ndlib/rof
-  revision: e8f355299a32271cd5f4e7908f2bc93174d1729a
+  revision: 96ee4c3456a8554950714fb09acf500aa323dd5f
   specs:
-    rof (1.3.0)
+    rof (1.3.1)
       deprecation (~> 0.1)
       ebnf
       json-ld
@@ -22,9 +22,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.4.1)
-      activesupport (= 5.2.4.1)
-    activesupport (5.2.4.1)
+    activemodel (5.2.4.2)
+      activesupport (= 5.2.4.2)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -53,7 +53,7 @@ GEM
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
-    google-api-client (0.30.10)
+    google-api-client (0.32.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.10.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -61,8 +61,8 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.10)
-    google_drive (3.0.3)
-      google-api-client (>= 0.11.0, < 0.31.0)
+    google_drive (3.0.4)
+      google-api-client (>= 0.11.0, < 0.37.0)
       googleauth (>= 0.5.0, < 1.0.0)
       nokogiri (>= 1.5.3, < 2.0.0)
     googleauth (0.9.0)
@@ -76,7 +76,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
-    highline (1.7.8)
+    highline (2.0.3)
     hooks (0.3.6)
       uber (~> 0.0.4)
     htmlentities (4.3.4)
@@ -101,11 +101,11 @@ GEM
     multipart-post (2.1.1)
     mustermann (0.3.1)
       tool (~> 0.2)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
+    net-scp (2.0.0)
+      net-ssh (>= 2.6.5, < 6.0.0)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (4.1.0)
+    net-ssh (5.2.0)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     netrc (0.11.0)
@@ -114,12 +114,12 @@ GEM
       rest-client (~> 1.6)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    os (1.0.1)
-    public_suffix (4.0.3)
-    rack (1.6.12)
+    os (1.1.0)
+    public_suffix (4.0.4)
+    rack (1.6.13)
     rack-protection (1.5.5)
       rack
-    rake (12.0.0)
+    rake (13.0.1)
     rdf (2.2.12)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -143,9 +143,9 @@ GEM
       rdf (>= 2.2, < 4.0)
     rdf-xsd (2.2.1)
       rdf (>= 2.2, < 4.0)
-    redis (3.3.3)
-    redis-namespace (1.5.3)
-      redis (~> 3.0, >= 3.0.4)
+    redis (4.1.3)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -187,12 +187,12 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     tool (0.2.3)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.0.15)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     vegas (0.1.11)
       rack (>= 1.0.0)
 
@@ -213,4 +213,4 @@ DEPENDENCIES
   signet (= 0.11)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
pick up  rof version 1.31, which populates  "content-meta" if "content-file" is present