### PR TITLE
ci: add go test ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Curate Batch CI
+
+on:
+  push:
+    branches-ignore: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go: [ '1.16', '1.15' ]
+      fail-fast: false
+    name: Go ${{ matrix.go }} Test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Run build
+        run: go build
+      - name: Testing
+        run: |
+          cd batchs
+          go test


### PR DESCRIPTION
Add runners for Go 1.15 and 1.16 that run the test suite.

Closes ESU-1643